### PR TITLE
Include css/bootstrap.css bower.json in "main"

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,7 @@
   ],
   "description": "Distribution packages for Bootswatch themes. Just the ones ready to use with Bower.",
   "main": [
+    "css/bootstrap.css",
     "js/bootstrap.js"
   ],
   "dependencies": {


### PR DESCRIPTION
I noticed this was missing when trying to do a grunt build with Yeoman scaffold. It looks like the css reference was mistakenly taken out when the font files were removed. See Bootstraps bower.json https://github.com/twbs/bootstrap/blob/master/bower.json