### PR TITLE
Add bootstrap.css to bower main attribute

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,7 @@
   ],
   "description": "Distribution packages for Bootswatch themes. Just the ones ready to use with Bower.",
   "main": [
+    "css/bootstrap.css"
     "js/bootstrap.js"
   ],
   "dependencies": {


### PR DESCRIPTION
Css isn't copied when including bootswatch-dist using grunt wiredep. Would be good if the css was copied together with the javascript files.